### PR TITLE
webosiot_rule.py: replace git:// with https://

### DIFF
--- a/scripts/webos-iot-scripts/webosiot_rule.py
+++ b/scripts/webos-iot-scripts/webosiot_rule.py
@@ -15,11 +15,11 @@
 # ('remove', 'meta-updater')
 #
 # 2. append 'meta-webos-iot' layer to weboslayers.py of webosose
-# ('append', ('meta-webos-iot', 'auto', 'git://github.com/webosose/meta-webos-iot.git', 'branch=webos-headless', 'meta-webos-iot')),
+# ('append', ('meta-webos-iot', 'auto', 'https://github.com/webosose/meta-webos-iot.git', 'branch=webos-headless', 'meta-webos-iot')),
 #
 # 3. insert 'meta-webos-iot' layer after 'meta-webos' layer of weboslayers.py of webosose
-# ('insert', 'meta-webos', ('meta-webos-iot', 41, 'git://github.com/webosose/meta-webos-iot.git', 'branch=webos-headless', 'meta-webos-iot')),
+# ('insert', 'meta-webos', ('meta-webos-iot', 41, 'https://github.com/webosose/meta-webos-iot.git', 'branch=webos-headless', 'meta-webos-iot')),
 
 webosiot_layer_rules = [
-('append', ('meta-webos-iot', 'auto', 'git://github.com/webosose/meta-webosose.git', '', '')),
+('append', ('meta-webos-iot', 'auto', 'https://github.com/webosose/meta-webosose.git', '', '')),
 ]

--- a/weboslayers.py
+++ b/weboslayers.py
@@ -77,7 +77,7 @@ webos_layers = [
 ('meta-webos-backports-3.2',  33, 'https://github.com/webosose/meta-webosose',              '', ''),
 ('meta-webos-backports-3.4',  35, 'https://github.com/webosose/meta-webosose',              '', ''),
 
-('meta-webos',                40, 'https://github.com/webosose/meta-webosose.git',          'branch=master,commit=e2989dc1', ''),
+('meta-webos',                40, 'https://github.com/webosose/meta-webosose.git',          'branch=master,commit=1e48d4b08', ''),
 
 ('meta-raspberrypi',          50, 'https://git.yoctoproject.org/git/meta-raspberrypi',      'branch=dunfell,commit=2e704f5', ''),
 ('meta-webos-raspberrypi',    51, 'https://github.com/webosose/meta-webosose.git',          '', ''),


### PR DESCRIPTION
* github decided that nobody should use git://
  https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

  and starting today all the builds were failing to fetch the metadata
  layers from github like:

  2021-11-01T18:53:26 INFO _main_ Updating [meta-ros]
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

  this was just a "test" as they said:
  "November 2, 2021: We'll also run several short brownouts on this date."
  and it will be completely disabled on January 11 2022.

  Update the URLs of all git repos, not only the ones hosted on github with:

  for i in git://git.yoctoproject.org/meta-virtualization \
           git://github.com/openembedded/meta-openembedded.git \
           git://github.com/openembedded/bitbake.git \
           git://github.com/openembedded/openembedded-core.git \
           git://github.com/uptane/meta-updater.git \
           git://git.openembedded.org/meta-python2 \
           git://code.qt.io/yocto/meta-qt6.git  \
           git://git.yoctoproject.org/meta-raspberrypi \
           git://git.yoctoproject.org/meta-security \
           git://github.com/ros/meta-ros.git \
           git://github.com/ros/meta-ros-webos.git \
           git://github.com/shr-project/meta-webosose.git \
           git://github.com/meta-qt5/meta-qt5.git \
           git://github.com/advancedtelematic/meta-updater.git \
           git://github.com/webosose/meta-webosose.git \
           git://git.yoctoproject.org/meta-gplv2 \
      ; do sed -i "s#'$i',  #'${i/git:/https:}',#g" weboslayers.py; done

  for i in https://git.yoctoproject.org/meta-virtualization \
           https://git.yoctoproject.org/meta-raspberrypi \
           https://git.yoctoproject.org/meta-security \
           https://git.yoctoproject.org/meta-gplv2 \
      ; do sed -i "s#'$i',    #'${i/org\/meta/org\/git\/meta}',#g" weboslayers.py; done

Change-Id: Idd1f9d8a250eeefd809c79771b448f011748ce94