### PR TITLE
Add meta-neural-network layers to use the nnstreamer

### DIFF
--- a/weboslayers.py
+++ b/weboslayers.py
@@ -67,8 +67,9 @@ webos_layers = [
 ('meta-networking',           12, 'https://github.com/openembedded/meta-openembedded.git',  '', 'meta-oe'),
 ('meta-python',               13, 'https://github.com/openembedded/meta-openembedded.git',  '', 'meta-oe'),
 ('meta-filesystems',          14, 'https://github.com/openembedded/meta-openembedded.git',  '', 'meta-oe'),
+('meta-neural-network',       15, 'https://github.com/nnstreamer/meta-neural-network.git',  'branch=master,commit=e4a32d6', ''),
 
-('meta-clang',                15, 'https://github.com/kraj/meta-clang.git',                 'branch=kirkstone,commit=1602c0a', ''),
+('meta-clang',                16, 'https://github.com/kraj/meta-clang.git',                 'branch=kirkstone,commit=1602c0a', ''),
 ('meta-virtualization',       17, 'https://git.yoctoproject.org/git/meta-virtualization',   'branch=kirkstone,commit=88327090', ''),
 
 ('meta-qt6',                  20, 'https://code.qt.io/yocto/meta-qt6.git',                  'branch=6.6.0,commit=v6.6.0', ''),


### PR DESCRIPTION
:Release Notes:
Add meta-neural-network layers to use the nnstreamer

:Detailed Notes:
Add meta-neural-network layers to use the nnstreamer

:Testing Performed:
Only build tested.

:QA Notes:
No change to image.

:Issues Addressed: