### PR TITLE
Add QEMU render environment setup for graphics testing

### DIFF
--- a/build-templates/webos-render.conf.sample
+++ b/build-templates/webos-render.conf.sample
@@ -1,0 +1,193 @@
+# webOS QEMU Render Environment Configuration Template
+#
+# This is a sample configuration for setting up graphics rendering in QEMU.
+# Copy this file to the root directory and customize as needed:
+#   cp build-templates/webos-render.conf.sample webos-render.conf
+#
+# Then include it in your webos-local.conf:
+#   require webos-render.conf
+
+# ==============================================================================
+# Graphics Features Configuration
+# ==============================================================================
+
+# Enable graphics-related DISTRO_FEATURES
+# These features enable OpenGL, Vulkan, and Wayland support in the build
+DISTRO_FEATURES:append = " opengl vulkan wayland"
+
+# For X11 support (optional, uncomment if needed)
+#DISTRO_FEATURES:append = " x11"
+
+# ==============================================================================
+# QEMU Graphics Configuration
+# ==============================================================================
+
+# Basic graphics adapter
+# Options: -vga std (standard VGA), -vga virtio (VirtIO VGA), -vga qxl
+QB_GRAPHICS ?= "-vga std"
+
+# Display backend configuration
+# sdl,gl=on: SDL2 with OpenGL acceleration
+# gtk,gl=on: GTK with OpenGL acceleration
+# vnc=:1: VNC server on port 5901 (headless)
+QB_OPT_APPEND:append = " -display sdl,gl=on"
+
+# VirtIO GPU for hardware-accelerated 3D (virgl)
+# This enables GPU pass-through for better performance
+# Comment out if you experience graphics driver issues
+QB_OPT_APPEND:append = " -device virtio-vga-gl"
+
+# Alternative: Use QXL for better 2D performance with Spice
+#QB_OPT_APPEND:append = " -device qxl-vga"
+
+# ==============================================================================
+# QEMU Memory and Performance
+# ==============================================================================
+
+# Memory allocation (in MB)
+# Increase for graphics-intensive workloads
+QB_MEM ?= "-m 2048"
+
+# For 4GB memory:
+#QB_MEM ?= "-m 4096"
+
+# Enable KVM hardware acceleration (if available on host)
+# This provides near-native performance on x86_64 hosts
+QB_OPT_APPEND:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'kvm', '-enable-kvm', '', d)}"
+
+# CPU configuration (optional)
+# Use host CPU model for best KVM performance
+#QB_CPU = "-cpu host"
+# Or specify number of cores:
+#QB_CPU_KVM = "-cpu host -smp 4"
+
+# ==============================================================================
+# Audio Configuration (Optional)
+# ==============================================================================
+
+# PulseAudio support
+#QB_AUDIO_OPT = "-audiodev pa,id=snd0"
+#QB_AUDIO_DRV = "-device AC97,audiodev=snd0"
+
+# ALSA support
+#QB_AUDIO_OPT = "-audiodev alsa,id=snd0"
+#QB_AUDIO_DRV = "-device AC97,audiodev=snd0"
+
+# ==============================================================================
+# Qt6 Graphics Configuration
+# ==============================================================================
+
+# Qt Platform Abstraction (QPA) plugin
+# Options: wayland, xcb (X11), eglfs (direct framebuffer)
+QT_QPA_PLATFORM ?= "wayland"
+
+# Qt Quick rendering backend
+# Options: software, opengl, openvg
+QT_QUICK_BACKEND ?= "software"
+
+# For OpenGL backend (requires proper GPU support):
+#QT_QUICK_BACKEND ?= "opengl"
+
+# ==============================================================================
+# Mesa/OpenGL Configuration
+# ==============================================================================
+
+# Mesa package configuration
+# Enable LLVM-accelerated Gallium drivers
+PACKAGECONFIG:append:pn-mesa = " gallium-llvm"
+
+# Enable virgl (VirtIO GPU 3D driver)
+PACKAGECONFIG:append:pn-mesa = " virgl"
+
+# Enable additional Mesa drivers (optional)
+#PACKAGECONFIG:append:pn-mesa = " egl gles gbm"
+
+# DRI driver selection (optional)
+#MESA_DRI_DRIVERS = "swrast"
+
+# ==============================================================================
+# Image Features for Graphics Testing
+# ==============================================================================
+
+# Add debugging and development tools
+EXTRA_IMAGE_FEATURES += "debug-tweaks tools-debug tools-profile"
+
+# ==============================================================================
+# Graphics Testing Tools
+# ==============================================================================
+
+# Add graphics testing and debugging tools to the image
+IMAGE_INSTALL:append = " \
+    mesa-demos \
+    kmscube \
+    weston \
+    weston-examples \
+"
+
+# Qt6 examples (optional, increases image size)
+#IMAGE_INSTALL:append = " qt6-qtbase-examples"
+
+# Vulkan tools (if DISTRO_FEATURES includes vulkan)
+#IMAGE_INSTALL:append = " vulkan-tools"
+
+# X11 tools (if using X11)
+#IMAGE_INSTALL:append = " xorg-minimal xterm"
+
+# ==============================================================================
+# Advanced Options
+# ==============================================================================
+
+# Serial console configuration
+#QB_SERIAL_OPT = "-serial mon:stdio"
+
+# Network configuration
+# slirp: User-mode networking (default, no root required)
+# tap: TAP networking (requires root, better performance)
+#QB_SLIRP_OPT = "-netdev user,id=net0"
+#QB_TAP_OPT = "-netdev tap,id=net0,ifname=tap0,script=no,downscript=no"
+
+# Shared folder between host and guest (9p virtio)
+#QB_DRIVE_TYPE = "/dev/vdb"
+#QB_FSINFO = "virtio-9p"
+
+# ==============================================================================
+# Troubleshooting Options
+# ==============================================================================
+
+# Disable virgl if you encounter graphics driver issues
+#QB_OPT_APPEND:remove = " -device virtio-vga-gl"
+
+# Use software rendering only (llvmpipe)
+#QB_GRAPHICS = "-vga std"
+#QB_OPT_APPEND:remove = " -display sdl,gl=on"
+#QB_OPT_APPEND:append = " -display sdl,gl=off"
+
+# Increase log verbosity for debugging
+#QB_OPT_APPEND:append = " -d guest_errors"
+
+# ==============================================================================
+# Profile-Specific Configurations
+# ==============================================================================
+
+# Uncomment the profile you want to use:
+
+## Profile 1: Maximum Performance (requires KVM and GPU)
+#QB_MEM = "-m 4096"
+#QB_CPU_KVM = "-cpu host -smp 4"
+#QB_OPT_APPEND:append = " -device virtio-vga-gl -display sdl,gl=on -enable-kvm"
+
+## Profile 2: Software Rendering (no GPU required)
+#QB_GRAPHICS = "-vga std"
+#QB_OPT_APPEND:remove = " -device virtio-vga-gl"
+#QB_OPT_APPEND:append = " -display sdl,gl=off"
+#QT_QUICK_BACKEND = "software"
+
+## Profile 3: Headless/VNC (for CI/CD)
+#QB_GRAPHICS = "-vga std"
+#QB_OPT_APPEND:remove = " -display sdl,gl=on"
+#QB_OPT_APPEND:append = " -display vnc=:1"
+
+## Profile 4: X11 Testing
+#DISTRO_FEATURES:append = " x11"
+#QT_QPA_PLATFORM = "xcb"
+#IMAGE_INSTALL:append = " xorg-minimal xterm"

--- a/docs/RENDER_ENVIRONMENT.md
+++ b/docs/RENDER_ENVIRONMENT.md
@@ -1,0 +1,334 @@
+# webOS QEMU Render Environment Setup
+
+This guide explains how to set up a development and testing environment for webOS with QEMU graphics rendering support.
+
+## Overview
+
+The render environment provides:
+- **Hardware-accelerated 3D graphics** using VirtIO GPU (virgl)
+- **OpenGL and Vulkan support** for modern graphics workloads
+- **Wayland display server** for compositor testing
+- **Qt6 graphics testing** with proper rendering backend
+- **Graphics debugging tools** (mesa-demos, kmscube, etc.)
+
+## Prerequisites
+
+### System Requirements
+
+- **Ubuntu 20.04 or 22.04** (recommended)
+- **Minimum 8GB RAM** (16GB recommended for comfortable development)
+- **OpenGL support** (hardware or software rendering)
+- **X11 or Wayland** display server
+
+### Required Packages
+
+Install system dependencies:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    qemu-system-x86 \
+    qemu-system-arm \
+    libgl1-mesa-dev \
+    libvirglrenderer1 \
+    libsdl2-2.0-0 \
+    mesa-utils \
+    pulseaudio
+```
+
+## Quick Start
+
+### 1. Run Setup Script
+
+```bash
+./scripts/setup-render-env.sh
+```
+
+This script will:
+- Check your system for graphics support
+- Verify required dependencies
+- Create `webos-render.conf` with graphics settings
+- Generate helper scripts for running QEMU
+
+### 2. Enable Render Configuration
+
+Add the render configuration to your build:
+
+```bash
+echo 'require webos-render.conf' >> webos-local.conf
+```
+
+### 3. Configure Build Environment
+
+```bash
+./mcf -p 0 -b 0 qemux86-64
+source oe-init-build-env
+```
+
+### 4. Build the Image
+
+```bash
+bitbake webos-image
+```
+
+This will take 2-6 hours on first build (subsequent builds are faster with sstate-cache).
+
+### 5. Run QEMU with Graphics
+
+```bash
+./scripts/run-qemu-graphics.sh
+```
+
+## Supported QEMU Machines
+
+The render environment supports these QEMU machines:
+
+| Machine | Architecture | Notes |
+|---------|--------------|-------|
+| `qemux86-64` | x86_64 | **Recommended** - Best performance with KVM |
+| `qemux86` | x86 (32-bit) | Legacy support |
+| `qemuarm` | ARM | Slower, no KVM on x86 hosts |
+
+## Graphics Configuration
+
+### VirtIO GPU (virgl)
+
+The default configuration uses VirtIO GPU for hardware-accelerated 3D:
+
+```bitbake
+QB_OPT_APPEND:append = " -device virtio-vga-gl"
+QB_OPT_APPEND:append = " -display sdl,gl=on"
+```
+
+This enables:
+- OpenGL acceleration in the guest
+- GPU command forwarding to the host
+- Better performance for Qt6 and Wayland compositors
+
+### Display Options
+
+You can customize the display backend when running QEMU:
+
+**SDL with OpenGL (default):**
+```bash
+./scripts/run-qemu-graphics.sh
+```
+
+**GTK backend:**
+```bash
+runqemu qemux86-64 webos-image qemuparams="-display gtk,gl=on"
+```
+
+**VNC (headless):**
+```bash
+runqemu qemux86-64 webos-image qemuparams="-display vnc=:1"
+```
+
+Then connect with: `vncviewer localhost:5901`
+
+### Memory Configuration
+
+Default memory is 2GB. For graphics-intensive testing, increase it:
+
+```bash
+# In webos-render.conf or webos-local.conf
+QB_MEM = "-m 4096"
+```
+
+## Testing Graphics Rendering
+
+### Check OpenGL Support
+
+Inside QEMU:
+
+```bash
+# Check OpenGL renderer
+glxinfo | grep "OpenGL renderer"
+
+# Run OpenGL demo
+glxgears
+
+# Test KMS/DRM
+kmscube
+```
+
+### Test Qt6 Rendering
+
+```bash
+# List Qt6 examples
+ls /usr/share/qt6/examples/
+
+# Run a Qt6 Quick example
+/usr/share/qt6/examples/quick/quickwidgets/quickwidget/quickwidget
+```
+
+### Wayland Compositor Testing
+
+```bash
+# Start Weston compositor
+weston &
+
+# Run Weston examples
+weston-simple-egl
+weston-flower
+```
+
+## Performance Optimization
+
+### Enable KVM Acceleration
+
+For best performance on x86_64 hosts:
+
+```bash
+# Check KVM availability
+ls -l /dev/kvm
+
+# Add your user to kvm group
+sudo usermod -aG kvm $USER
+# Log out and back in for changes to take effect
+```
+
+The helper script automatically enables KVM if available.
+
+### CPU and Thread Settings
+
+Adjust parallel build settings in `conf/local.conf`:
+
+```bitbake
+# Use 75% of CPU cores
+BB_NUMBER_THREADS = "12"
+PARALLEL_MAKE = "-j 12"
+```
+
+### Graphics Driver Selection
+
+For software rendering (no GPU):
+```bitbake
+# In webos-local.conf
+QB_OPT_APPEND:remove = " -device virtio-vga-gl"
+QB_GRAPHICS = "-vga std"
+```
+
+## Troubleshooting
+
+### No Graphics Display
+
+**Symptom:** QEMU starts but shows no graphics
+
+**Solution:**
+```bash
+# Check display environment
+echo $DISPLAY
+
+# If empty, export it
+export DISPLAY=:0
+
+# Or use VNC
+runqemu qemux86-64 webos-image qemuparams="-display vnc=:1"
+```
+
+### OpenGL Errors
+
+**Symptom:** `failed to create virgl renderer`
+
+**Solution:**
+```bash
+# Check Mesa/virgl installation
+ldconfig -p | grep virglrenderer
+
+# Install if missing
+sudo apt-get install libvirglrenderer1
+
+# Or disable virgl
+QB_OPT_APPEND:remove = " -device virtio-vga-gl"
+```
+
+### Slow Performance
+
+**Symptom:** Graphics rendering is very slow
+
+**Solutions:**
+1. Enable KVM (x86_64 only)
+2. Increase QEMU memory: `QB_MEM = "-m 4096"`
+3. Use hardware rendering (not llvmpipe)
+4. Reduce graphics features if on software rendering
+
+### Build Failures
+
+**Symptom:** `mesa` or `qt6` build failures
+
+**Solution:**
+```bash
+# Clean and rebuild
+bitbake -c cleanall mesa
+bitbake mesa
+
+# Check build logs
+cat BUILD/tmp/work/*/mesa/*/temp/log.do_compile
+```
+
+## Advanced Configuration
+
+### Custom QEMU Options
+
+Edit `scripts/run-qemu-graphics.sh` or pass custom parameters:
+
+```bash
+./scripts/run-qemu-graphics.sh qemuparams="-smp 4 -cpu host"
+```
+
+### Vulkan Support
+
+Add Vulkan to your configuration:
+
+```bitbake
+# In webos-local.conf
+DISTRO_FEATURES:append = " vulkan"
+IMAGE_INSTALL:append = " vulkan-tools"
+```
+
+Test with: `vulkaninfo`
+
+### Network Configuration
+
+QEMU uses slirp networking by default. For better networking:
+
+```bash
+# Create TAP interface (requires root)
+sudo ip tuntap add dev tap0 mode tap
+sudo ip link set tap0 up
+sudo ip addr add 192.168.7.1/24 dev tap0
+
+# Use in QEMU
+runqemu qemux86-64 webos-image slirp
+```
+
+## CI/CD Integration
+
+For automated testing in headless environments:
+
+```bash
+# Use Xvfb (virtual framebuffer)
+Xvfb :99 -screen 0 1280x1024x24 &
+export DISPLAY=:99
+
+./scripts/run-qemu-graphics.sh qemuparams="-display gtk"
+```
+
+## Additional Resources
+
+- [webOS OSE Documentation](https://www.webosose.org/docs/)
+- [Yocto QEMU Documentation](https://docs.yoctoproject.org/dev-manual/qemu.html)
+- [VirtIO GPU](https://www.kraxel.org/blog/2016/09/using-virtio-gpu-with-libvirt-and-spice/)
+- [Mesa virgl](https://virgil3d.github.io/)
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check `BUILD/tmp/log/cooker/qemux86-64/console-latest.log`
+2. Review QEMU output for errors
+3. Verify graphics drivers with `glxinfo`
+4. Test with software rendering first
+
+For webOS-specific questions, consult the [webOS OSE forums](https://forum.webosose.org/).

--- a/scripts/run-qemu-graphics.sh
+++ b/scripts/run-qemu-graphics.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+
+# Copyright (c) 2025 webOS Open Source Edition
+# Helper script to launch QEMU with graphics rendering enabled
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_WEBOS_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+# Usage information
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Launch QEMU with graphics rendering for webOS testing.
+
+OPTIONS:
+    -m, --machine MACHINE    Target machine (default: qemux86-64)
+                            Options: qemux86, qemux86-64, qemuarm
+
+    -i, --image IMAGE       Image to boot (default: webos-image)
+
+    -d, --display DISPLAY   Display backend (default: sdl)
+                            Options: sdl, gtk, vnc, none
+
+    --memory SIZE          Memory in MB (default: 2048)
+
+    --no-virgl             Disable VirtIO GPU acceleration
+
+    --no-kvm               Disable KVM acceleration
+
+    --serial               Enable serial console output
+
+    --nographic            Run in non-graphical mode (serial only)
+
+    -h, --help             Show this help message
+
+EXAMPLES:
+    # Basic usage with defaults
+    $0
+
+    # Use qemux86 machine
+    $0 --machine qemux86
+
+    # Use GTK display with 4GB memory
+    $0 --display gtk --memory 4096
+
+    # Headless VNC mode
+    $0 --display vnc
+
+    # Disable GPU acceleration (software rendering)
+    $0 --no-virgl
+
+    # Non-graphical mode with serial console
+    $0 --nographic
+
+EOF
+}
+
+# Default configuration
+MACHINE="${MACHINE:-qemux86-64}"
+IMAGE="${IMAGE:-webos-image}"
+DISPLAY_BACKEND="sdl"
+MEMORY="2048"
+ENABLE_VIRGL=true
+ENABLE_KVM=true
+ENABLE_SERIAL=false
+NOGRAPHIC=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -m|--machine)
+            MACHINE="$2"
+            shift 2
+            ;;
+        -i|--image)
+            IMAGE="$2"
+            shift 2
+            ;;
+        -d|--display)
+            DISPLAY_BACKEND="$2"
+            shift 2
+            ;;
+        --memory)
+            MEMORY="$2"
+            shift 2
+            ;;
+        --no-virgl)
+            ENABLE_VIRGL=false
+            shift
+            ;;
+        --no-kvm)
+            ENABLE_KVM=false
+            shift
+            ;;
+        --serial)
+            ENABLE_SERIAL=true
+            shift
+            ;;
+        --nographic)
+            NOGRAPHIC=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Source the build environment
+if [ ! -f "${BUILD_WEBOS_DIR}/oe-init-build-env" ]; then
+    print_error "Build environment not initialized."
+    echo ""
+    echo "Please run the following commands first:"
+    echo "  cd $BUILD_WEBOS_DIR"
+    echo "  ./mcf -p 0 -b 0 $MACHINE"
+    exit 1
+fi
+
+cd "$BUILD_WEBOS_DIR"
+source oe-init-build-env > /dev/null
+
+# Build QEMU options
+QEMU_OPTS=""
+
+# Memory configuration
+QEMU_OPTS="$QEMU_OPTS -m $MEMORY"
+
+# Display configuration
+if [ "$NOGRAPHIC" = true ]; then
+    QEMU_OPTS="$QEMU_OPTS -nographic"
+    print_info "Running in non-graphical mode (serial console only)"
+else
+    case "$DISPLAY_BACKEND" in
+        sdl)
+            if $ENABLE_VIRGL; then
+                QEMU_OPTS="$QEMU_OPTS -display sdl,gl=on"
+            else
+                QEMU_OPTS="$QEMU_OPTS -display sdl"
+            fi
+            ;;
+        gtk)
+            if $ENABLE_VIRGL; then
+                QEMU_OPTS="$QEMU_OPTS -display gtk,gl=on"
+            else
+                QEMU_OPTS="$QEMU_OPTS -display gtk"
+            fi
+            ;;
+        vnc)
+            QEMU_OPTS="$QEMU_OPTS -display vnc=:1"
+            print_info "VNC server will be available at localhost:5901"
+            ;;
+        none)
+            QEMU_OPTS="$QEMU_OPTS -display none"
+            ;;
+        *)
+            print_error "Unknown display backend: $DISPLAY_BACKEND"
+            exit 1
+            ;;
+    esac
+fi
+
+# VirtIO GPU configuration
+if $ENABLE_VIRGL && [ "$NOGRAPHIC" = false ]; then
+    QEMU_OPTS="$QEMU_OPTS -device virtio-vga-gl"
+    print_info "VirtIO GPU acceleration enabled"
+else
+    QEMU_OPTS="$QEMU_OPTS -vga std"
+    if [ "$NOGRAPHIC" = false ]; then
+        print_warning "VirtIO GPU disabled, using software rendering"
+    fi
+fi
+
+# KVM configuration
+if $ENABLE_KVM; then
+    if [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+        QEMU_OPTS="$QEMU_OPTS -enable-kvm"
+        print_success "KVM acceleration enabled"
+    else
+        print_warning "KVM not available, using software emulation (slower)"
+        print_warning "To enable KVM: sudo usermod -aG kvm $USER (then log out/in)"
+    fi
+fi
+
+# Audio support
+if command -v pulseaudio &> /dev/null || pgrep -x pulseaudio > /dev/null; then
+    QEMU_OPTS="$QEMU_OPTS -audiodev pa,id=snd0 -device AC97,audiodev=snd0"
+    print_info "PulseAudio support enabled"
+fi
+
+# Serial console
+if $ENABLE_SERIAL; then
+    QEMU_OPTS="$QEMU_OPTS -serial mon:stdio"
+    print_info "Serial console enabled"
+fi
+
+# Check if image exists
+IMAGE_DIR="${BUILD_WEBOS_DIR}/BUILD/deploy/images/${MACHINE}"
+if [ ! -d "$IMAGE_DIR" ]; then
+    print_error "Image directory not found: $IMAGE_DIR"
+    echo ""
+    echo "Please build the image first:"
+    echo "  source oe-init-build-env"
+    echo "  bitbake $IMAGE"
+    exit 1
+fi
+
+# Display launch information
+echo ""
+echo "=========================================="
+echo "  webOS QEMU Graphics Testing"
+echo "=========================================="
+echo ""
+print_info "Machine:        $MACHINE"
+print_info "Image:          $IMAGE"
+print_info "Display:        $DISPLAY_BACKEND"
+print_info "Memory:         ${MEMORY}MB"
+print_info "VirtIO GPU:     $ENABLE_VIRGL"
+print_info "KVM:            $ENABLE_KVM"
+echo ""
+print_info "QEMU options:   $QEMU_OPTS"
+echo ""
+echo "=========================================="
+echo ""
+
+# Export display if not set
+if [ -z "$DISPLAY" ] && [ "$NOGRAPHIC" = false ] && [ "$DISPLAY_BACKEND" != "vnc" ]; then
+    print_warning "DISPLAY environment variable not set"
+    export DISPLAY=:0
+    print_info "Setting DISPLAY=$DISPLAY"
+fi
+
+# Run QEMU
+print_info "Starting QEMU..."
+echo ""
+
+# Check if runqemu-wrapper exists, otherwise use runqemu directly
+if command -v runqemu &> /dev/null; then
+    exec runqemu "$MACHINE" "$IMAGE" qemuparams="$QEMU_OPTS" "$@"
+else
+    print_error "runqemu command not found. Make sure you've sourced oe-init-build-env"
+    exit 1
+fi

--- a/scripts/setup-render-env.sh
+++ b/scripts/setup-render-env.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+
+# Copyright (c) 2025 webOS Open Source Edition
+# Setup script for QEMU render/graphics testing environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_WEBOS_DIR="$(dirname "$SCRIPT_DIR")"
+RENDER_CONF="${BUILD_WEBOS_DIR}/webos-render.conf"
+
+echo "=========================================="
+echo "webOS QEMU Render Environment Setup"
+echo "=========================================="
+echo ""
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+# Check if running on a system with display capabilities
+check_display_support() {
+    echo "Checking display support..."
+
+    if [ -n "$DISPLAY" ]; then
+        print_status "X11 display detected: $DISPLAY"
+        GRAPHICS_BACKEND="x11"
+    elif [ -n "$WAYLAND_DISPLAY" ]; then
+        print_status "Wayland display detected: $WAYLAND_DISPLAY"
+        GRAPHICS_BACKEND="wayland"
+    else
+        print_warning "No display server detected. Graphics will use virtual framebuffer."
+        GRAPHICS_BACKEND="headless"
+    fi
+}
+
+# Check for required packages
+check_dependencies() {
+    echo ""
+    echo "Checking system dependencies..."
+
+    local missing_packages=()
+
+    # Essential QEMU packages
+    if ! command -v qemu-system-x86_64 &> /dev/null; then
+        missing_packages+=("qemu-system-x86")
+    fi
+
+    # Graphics libraries
+    if ! ldconfig -p | grep -q libGL.so; then
+        missing_packages+=("libgl1-mesa-dev")
+    fi
+
+    if ! ldconfig -p | grep -q libvirglrenderer; then
+        missing_packages+=("libvirglrenderer1")
+    fi
+
+    # SDL2 for QEMU graphics
+    if ! ldconfig -p | grep -q libSDL2; then
+        missing_packages+=("libsdl2-2.0-0")
+    fi
+
+    if [ ${#missing_packages[@]} -gt 0 ]; then
+        print_warning "Missing packages detected: ${missing_packages[*]}"
+        echo ""
+        echo "Install them with:"
+        echo "  sudo apt-get install ${missing_packages[*]}"
+        echo ""
+        read -p "Would you like to continue anyway? [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    else
+        print_status "All required dependencies are installed"
+    fi
+}
+
+# Check OpenGL/Mesa support
+check_opengl_support() {
+    echo ""
+    echo "Checking OpenGL support..."
+
+    if command -v glxinfo &> /dev/null; then
+        GL_RENDERER=$(glxinfo | grep "OpenGL renderer" | cut -d':' -f2 | xargs || echo "Unknown")
+        GL_VERSION=$(glxinfo | grep "OpenGL version" | cut -d':' -f2 | xargs || echo "Unknown")
+        print_status "OpenGL Renderer: $GL_RENDERER"
+        print_status "OpenGL Version: $GL_VERSION"
+
+        # Check for hardware acceleration
+        if echo "$GL_RENDERER" | grep -qi "llvmpipe\|software"; then
+            print_warning "Software rendering detected (llvmpipe). Hardware acceleration may not be available."
+        fi
+    else
+        print_warning "glxinfo not found. Install mesa-utils to check OpenGL support."
+    fi
+}
+
+# Create render-specific configuration
+create_render_config() {
+    echo ""
+    echo "Creating render environment configuration..."
+
+    cat > "$RENDER_CONF" << 'EOF'
+# webOS QEMU Render Environment Configuration
+# This file contains settings optimized for graphics testing with QEMU
+
+# Enable graphics features for testing
+DISTRO_FEATURES:append = " opengl vulkan wayland"
+
+# QEMU graphics configuration
+QB_GRAPHICS ?= "-vga std"
+QB_OPT_APPEND:append = " -display sdl,gl=on"
+
+# Enable virgl (VirtIO GPU) for hardware-accelerated 3D
+QB_OPT_APPEND:append = " -device virtio-vga-gl"
+
+# Memory settings for graphics workloads (increase if needed)
+QB_MEM ?= "-m 2048"
+
+# Enable KVM if available for better performance
+QB_OPT_APPEND:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'kvm', '-enable-kvm', '', d)}"
+
+# Qt6 graphics settings for webOS
+QT_QPA_PLATFORM ?= "wayland"
+QT_QUICK_BACKEND ?= "software"
+
+# Mesa/DRI settings
+PACKAGECONFIG:append:pn-mesa = " gallium-llvm"
+PACKAGECONFIG:append:pn-mesa = " virgl"
+
+# Enable additional image features for testing
+EXTRA_IMAGE_FEATURES += "debug-tweaks tools-debug tools-profile"
+
+# Add graphics testing tools to the image
+IMAGE_INSTALL:append = " \
+    mesa-demos \
+    kmscube \
+    weston \
+    weston-examples \
+    qt6-qtbase-examples \
+"
+EOF
+
+    print_status "Created render configuration: $RENDER_CONF"
+    echo ""
+    echo "To use this configuration, add the following to your webos-local.conf:"
+    echo "  require $(realpath --relative-to="${BUILD_WEBOS_DIR}" "$RENDER_CONF")"
+}
+
+# Create helper script to run QEMU with graphics
+create_run_script() {
+    echo ""
+    echo "Creating QEMU graphics launcher script..."
+
+    local RUN_SCRIPT="${SCRIPT_DIR}/run-qemu-graphics.sh"
+
+    cat > "$RUN_SCRIPT" << 'RUNSCRIPT_EOF'
+#!/bin/bash
+
+# Helper script to launch QEMU with graphics rendering enabled
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_WEBOS_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Source the build environment
+if [ ! -f "${BUILD_WEBOS_DIR}/oe-init-build-env" ]; then
+    echo "Error: Build environment not initialized. Run './mcf' first."
+    exit 1
+fi
+
+cd "$BUILD_WEBOS_DIR"
+source oe-init-build-env > /dev/null
+
+# Default machine
+MACHINE=${MACHINE:-qemux86-64}
+IMAGE=${IMAGE:-webos-image}
+
+# Graphics options
+QEMU_GRAPHICS_OPTS="-vga std -display sdl,gl=on"
+QEMU_VIRTIO_GPU="-device virtio-vga-gl"
+QEMU_MEMORY="-m 2048"
+
+# Enable KVM if available
+if [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+    QEMU_KVM_OPTS="-enable-kvm"
+    echo "KVM acceleration enabled"
+else
+    QEMU_KVM_OPTS=""
+    echo "Warning: KVM not available, using software emulation (slower)"
+fi
+
+# Audio support (optional)
+QEMU_AUDIO_OPTS="-audiodev pa,id=snd0 -device AC97,audiodev=snd0"
+
+echo "=========================================="
+echo "Launching QEMU with Graphics Rendering"
+echo "=========================================="
+echo "Machine: $MACHINE"
+echo "Image: $IMAGE"
+echo ""
+
+# Check if image exists
+IMAGE_FILE="${BUILD_WEBOS_DIR}/BUILD/deploy/images/${MACHINE}/${IMAGE}-${MACHINE}.wic"
+if [ ! -f "$IMAGE_FILE" ] && [ ! -f "${IMAGE_FILE}.qemuboot.conf" ]; then
+    echo "Error: Image not found. Build it first with:"
+    echo "  bitbake $IMAGE"
+    exit 1
+fi
+
+# Run QEMU with graphics
+echo "Starting QEMU with graphics rendering..."
+echo ""
+
+# Use runqemu with custom options
+runqemu "$MACHINE" "$IMAGE" \
+    qemuparams="$QEMU_MEMORY $QEMU_KVM_OPTS $QEMU_GRAPHICS_OPTS $QEMU_VIRTIO_GPU $QEMU_AUDIO_OPTS" \
+    "$@"
+RUNSCRIPT_EOF
+
+    chmod +x "$RUN_SCRIPT"
+    print_status "Created QEMU launcher: $RUN_SCRIPT"
+}
+
+# Display summary
+display_summary() {
+    echo ""
+    echo "=========================================="
+    echo "Setup Complete!"
+    echo "=========================================="
+    echo ""
+    echo "Next steps:"
+    echo ""
+    echo "1. Add render configuration to your build:"
+    echo "   echo 'require webos-render.conf' >> webos-local.conf"
+    echo ""
+    echo "2. Configure and build the image:"
+    echo "   ./mcf -p 0 -b 0 qemux86-64"
+    echo "   source oe-init-build-env"
+    echo "   bitbake webos-image"
+    echo ""
+    echo "3. Run QEMU with graphics rendering:"
+    echo "   ./scripts/run-qemu-graphics.sh"
+    echo ""
+    echo "Graphics Backend: $GRAPHICS_BACKEND"
+    echo ""
+    echo "For more information, see: docs/RENDER_ENVIRONMENT.md"
+    echo ""
+}
+
+# Main execution
+main() {
+    check_display_support
+    check_dependencies
+    check_opengl_support
+    create_render_config
+    create_run_script
+    display_summary
+}
+
+main "$@"


### PR DESCRIPTION
This commit adds comprehensive support for setting up and running QEMU with graphics rendering for webOS development and testing.

New files:
- scripts/setup-render-env.sh: Setup script that checks system dependencies, creates configuration files, and prepares the render environment
- scripts/run-qemu-graphics.sh: Helper script to launch QEMU with graphics rendering, supporting multiple display backends (SDL, GTK, VNC), VirtIO GPU acceleration, and KVM
- build-templates/webos-render.conf.sample: Comprehensive configuration template with graphics features, QEMU options, Qt6 settings, and Mesa/OpenGL configuration
- docs/RENDER_ENVIRONMENT.md: Complete documentation covering setup, usage, troubleshooting, and advanced configuration

Features:
- Hardware-accelerated 3D graphics via VirtIO GPU (virgl)
- OpenGL and Vulkan support
- Wayland display server configuration
- Qt6 graphics testing support
- KVM acceleration when available
- Multiple display backends (SDL, GTK, VNC)
- Configurable memory and CPU settings
- Graphics testing tools (mesa-demos, kmscube, weston)

The render environment enables developers to test webOS graphics, compositors, and Qt6 applications in QEMU with proper GPU acceleration.